### PR TITLE
FIX: python-version needs to be in quotes

### DIFF
--- a/.github/workflows/pelican.yml
+++ b/.github/workflows/pelican.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10.3
+        python-version: "3.10.3"
     - uses: snok/install-poetry@v1
       with:
         version: 1.2.2


### PR DESCRIPTION
I *think* this will fix 5c9a88ee7400bb2b805b36028b4d7c2c0e420f96

```
Version 3.10.3 was not found in the local cache
  Error: The version '3.10.3' with architecture 'x64' was not found for Ubuntu 22.04.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```